### PR TITLE
Added handling for .vue files with no template and added --add-comments to Javascript extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,5 @@
 # vue-webpack-gettext
 
-> Extract and compile translations with vue-gettext and vue-loader, i.e. for .vue files with <template lang='pug'></template>
+this is fork of the original package found here: https://github.com/kennyki/vue-webpack-gettext
 
-## Introduction
-
-[vue-gettext](https://github.com/Polyconseil/vue-gettext) has an example of [Makefile](https://github.com/Polyconseil/vue-gettext/blob/master/Makefile) that demonstrates how to extract and compile translations.
-
-However, it requires own modifications to fit different requirements and is hard to share between projects. Furthermore, it's unable to extract strings from templates if you're using custom template language in vue files.
-
-```
-<template lang='pug'>
-h1.hero
-  translate Please translate me
-</template>
-```
-
-So, I created this helper library to:
-
-#### 1. Extract strings to be translated into a POT file
-
-Since you're using custom template language, you should already have `vue-loader` and the corresponding compiler, i.e. `pug` in the project. By leveraging those, it will:
-
-1. Use vue-loader's component parser to extract the template content.
-1. Use [consolidate.js](https://github.com/tj/consolidate.js/) to compile the content to HTML.
-1. Use [easygettext](https://github.com/Polyconseil/easygettext) to extract strings for translation.
-
-#### 2. Compile translated PO files into one or many translation JSON files
-
-`vue-gettext`'s Makefile will group all PO files' content into a single JSON file, which may not be ideal if you only want to load one language at a time (translated strings can be humongous in size).
-
-So this helper will give you an option to split them into a JSON file per language.
-
-## Usage
-
-1. Install GNU gettext tools:
-  - MacOS: `brew install gettext && brew link --force gettext`
-  - Windows: _need help_
-1. `npm install --save-dev vue-webpack-gettext`
-1. Ensure that template language engines (that you're using) are installed, i.e. `npm install --save-dev pug`
-  - Check [consolidate.js](https://github.com/tj/consolidate.js/) for supported engines
-1. To extract: `node node_modules/vue-webpack-gettext/extract --output static/template.pot --src src`
-1. To compile: `node node_modules/vue-webpack-gettext/compile --output static/locale --src static/translated --multiple`
-1. You can add [npm scripts](https://docs.npmjs.com/misc/scripts) to your project's package.json to ease the tasks execution
+It simply adds `--add-comments` to the command line argiments for Javascript extraction of translator comments

--- a/extract.js
+++ b/extract.js
@@ -72,6 +72,6 @@ Promise.all(renderPromises).then((results) => {
 
   // extract from js
   shell.exec(`xgettext --language=JavaScript --keyword=npgettext:1c,2,3 \
-    --from-code=utf-8 --join-existing --no-wrap \
+    --from-code=utf-8 --join-existing --add-comments --no-wrap \
     --output ${outputFile} ${jsFiles.join(' ')}`)
 })

--- a/extract.js
+++ b/extract.js
@@ -38,14 +38,14 @@ let renderPromises = vueFiles.map((file) => {
   let content = fs.readFileSync(file, 'utf8')
   let filename = path.basename(file)
   let output = parseVue(content, filename, false)
-  let templateLang = output.template.lang
+  let templateLang = output.template ? output.template.lang : null
   let renderFn = templateLang && consolidate[templateLang] && consolidate[templateLang].render
   let renderOpts = templateLang && require(`./extract-opts/${templateLang}`)
 
   // must be in html so that they can match when the app runs
   let renderPromise = renderFn
                       ? renderFn.call(consolidate, output.template.content, renderOpts)
-                      : Promise.resolve(output.template.content)
+                      : Promise.resolve(output.template ? output.template.content : '')
 
   return renderPromise.then((html) => {
     return {file, html}


### PR DESCRIPTION
Title says pretty much everything.

The fixes I made allow the extraction tool to work in case there are some .vue files which contain no `<template>` tag (functional components for example).

I also added the appropriate option to extract Javascript comments from situations like 
``` javascript
// comment for translators
this.$gettext('Some Text');
```
which was not correctly working before