### PR TITLE
Upgrade easygettext to latest

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -2,7 +2,7 @@ const shell = require('shelljs')
 const path = require('path')
 const fs = require('fs')
 const glob = require('glob')
-const po2json = require('easygettext/dist/compile').po2json
+const po2json = require('easygettext/src/compile').po2json
 
 const argv = require('yargs')
   .alias('output', 'o')

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "extract.js",
   "dependencies": {
     "consolidate": "^0.14.5",
-    "easygettext": "^1.2.2",
+    "easygettext": "^2.7.0",
     "glob": "^7.1.1",
     "promise": "^7.1.1",
     "shelljs": "^0.7.4",


### PR DESCRIPTION
Fixes critical vuln in constantinople.

`vue-webpack-gettext > easygettext > jade > constantinople`

https://nodesecurity.io/advisories/568
https://snyk.io/vuln/npm:constantinople:20180421